### PR TITLE
Bump runtime to node20 from node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,5 +74,5 @@ branding:
   icon: message-circle
   color: purple
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
Github has deprecated Node 16 on actions and is emitting deprecation warnings when this action is used.

(See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

This PR simply changes the runner from node16 to node20. 