### PR TITLE
feat: add truncate-separator input and markdown termination

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,9 @@ inputs:
     description: 'Truncation mode when the message exceeds the safe comment length. "artifact" (default) uploads the full message as a downloadable artifact and links it. "simple" truncates with a notice.'
     default: 'artifact'
     required: false
+  truncate-separator:
+    description: 'Custom separator inserted before the truncation notice. Useful for closing markdown blocks (e.g., "```\n\n---" to close a code fence). Defaults to "---".'
+    required: false
   comment-target:
     description: 'Where to post the comment. Use "pr" for pull request/issue comments (default) or "commit" for commit comments.'
     default: 'pr'

--- a/action.yml
+++ b/action.yml
@@ -1,110 +1,110 @@
-name: 'Add PR Comment'
-description: 'Add a comment to a pull request or commit'
+name: "Add PR Comment"
+description: "Add a comment to a pull request or commit"
 inputs:
   message:
-    description: 'The message to print.'
+    description: "The message to print."
     required: false
   message-path:
-    description: 'A path or list of paths to a file to print as a message instead of a string.'
+    description: "A path or list of paths to a file to print as a message instead of a string."
     required: false
   attach-path:
-    description: 'A file path or glob pattern for files to upload as artifacts and link in the comment.'
+    description: "A file path or glob pattern for files to upload as artifacts and link in the comment."
     required: false
   attach-name:
-    description: 'Name for the uploaded artifact. Defaults to pr-comment-attachments.'
-    default: 'pr-comment-attachments'
+    description: "Name for the uploaded artifact. Defaults to pr-comment-attachments."
+    default: "pr-comment-attachments"
     required: false
   attach-text:
-    description: 'Markdown text appended for attachments. Use %ARTIFACT_URL% as a placeholder for the download link.'
+    description: "Markdown text appended for attachments. Use %ARTIFACT_URL% as a placeholder for the download link."
     required: false
   message-id:
-    description: 'An optional id to use for this message.'
-    default: 'add-pr-comment'
+    description: "An optional id to use for this message."
+    default: "add-pr-comment"
     required: false
   refresh-message-position:
-    description: 'If a message with the same id, this option allow to refresh the position of the message to be the last one posted.'
-    default: 'false'
+    description: "If a message with the same id, this option allow to refresh the position of the message to be the last one posted."
+    default: "false"
     required: false
   repo-owner:
-    description: 'The repo owner.'
-    default: '${{ github.repository_owner }}'
+    description: "The repo owner."
+    default: "${{ github.repository_owner }}"
     required: false
   repo-name:
-    description: 'The repo name.'
-    default: '${{ github.event.repository.name }}'
+    description: "The repo name."
+    default: "${{ github.event.repository.name }}"
     required: false
   repo-token:
-    description: 'A GitHub token for API access. Defaults to {{ github.token }}.'
-    default: '${{ github.token }}'
+    description: "A GitHub token for API access. Defaults to {{ github.token }}."
+    default: "${{ github.token }}"
     required: false
   allow-repeats:
-    description: 'Allow messages to be repeated.'
-    default: 'false'
+    description: "Allow messages to be repeated."
+    default: "false"
     required: false
   proxy-url:
-    description: 'Proxy URL for comment creation'
+    description: "Proxy URL for comment creation"
     required: false
   status:
-    description: 'A job status for status headers. Defaults to {{ job.status }}.'
-    default: '${{ job.status }}'
+    description: "A job status for status headers. Defaults to {{ job.status }}."
+    default: "${{ job.status }}"
     required: false
   message-success:
-    description: 'Override the message when a run is successful.'
+    description: "Override the message when a run is successful."
     required: false
   message-failure:
-    description: 'Override the message when a run fails.'
+    description: "Override the message when a run fails."
     required: false
   message-cancelled:
-    description: 'Override the message when a run is cancelled.'
+    description: "Override the message when a run is cancelled."
     required: false
   message-skipped:
-    description: 'Override the message when a run is skipped.'
+    description: "Override the message when a run is skipped."
     required: false
   issue:
-    description: 'Override the message when a run is cancelled.'
+    description: "Override the message when a run is cancelled."
     required: false
   update-only:
-    description: 'Only update the comment if it already exists.'
+    description: "Only update the comment if it already exists."
     required: false
   preformatted:
-    description: 'Treat message text (from a file or input) as pre-formatted and place it in a codeblock.'
+    description: "Treat message text (from a file or input) as pre-formatted and place it in a codeblock."
     required: false
   truncate:
     description: 'Truncation mode when the message exceeds the safe comment length. "artifact" (default) uploads the full message as a downloadable artifact and links it. "simple" truncates with a notice.'
-    default: 'artifact'
+    default: "artifact"
     required: false
   truncate-separator:
-    description: 'Custom separator inserted before the truncation notice. Useful for closing markdown blocks (e.g., "```\n\n---" to close a code fence). Defaults to "---".'
+    description: 'Custom separator inserted before the truncation notice. Defaults to "---".'
     required: false
   comment-target:
     description: 'Where to post the comment. Use "pr" for pull request/issue comments (default) or "commit" for commit comments.'
-    default: 'pr'
+    default: "pr"
     required: false
   commit-sha:
     description: 'The commit SHA to comment on when comment-target is "commit". Defaults to the current commit.'
     required: false
   find:
-    description: 'A regular expression to find for replacement. Multiple lines become individual regular expressions.'
+    description: "A regular expression to find for replacement. Multiple lines become individual regular expressions."
   replace:
-    description: 'A replacement to use, overrides the message. Multple lines can replace same-indexed find patterns.'
+    description: "A replacement to use, overrides the message. Multple lines can replace same-indexed find patterns."
   delete-on-status:
-    description: 'Delete comment on specified status.'
+    description: "Delete comment on specified status."
 outputs:
   comment-created:
-    description: 'Whether a comment was created.'
+    description: "Whether a comment was created."
   comment-updated:
-    description: 'Whether a comment was updated.'
+    description: "Whether a comment was updated."
   comment-id:
-    description: 'If a comment was created or updated, the comment id.'
+    description: "If a comment was created or updated, the comment id."
   artifact-url:
-    description: 'If files were attached, the URL to download the artifact.'
+    description: "If files were attached, the URL to download the artifact."
   truncated:
-    description: 'Whether the message was truncated.'
+    description: "Whether the message was truncated."
   truncated-artifact-url:
-    description: 'If the message was truncated in artifact mode, the URL to download the full message.'
+    description: "If the message was truncated in artifact mode, the URL to download the full message."
 branding:
   icon: message-circle
   color: purple
 runs:
-  using: 'node24'
-  main: 'dist/index.js'
+  using: "node24"
+  main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -118212,6 +118212,7 @@ async function getInputs() {
         throw new Error(`Invalid truncate mode: "${truncateInput}". Must be "artifact" or "simple".`);
     }
     const truncate = truncateInput;
+    const truncateSeparator = getInput('truncate-separator', { required: false });
     const deleteOnStatus = getInput('delete-on-status', { required: false });
     const commentTarget = getInput('comment-target', { required: false }) || 'pr';
     if (commentTarget !== 'pr' && commentTarget !== 'commit') {
@@ -118242,6 +118243,7 @@ async function getInputs() {
         messageReplace,
         preformatted,
         truncate,
+        truncateSeparator: truncateSeparator || undefined,
         proxyUrl,
         pullRequestNumber: payload.pull_request?.number,
         refreshMessagePosition,
@@ -120371,21 +120373,61 @@ async function getIssueNumberFromCommitPullsList(octokit, owner, repo, commitSha
     return commitPullsList.data.length ? commitPullsList.data?.[0].number : null;
 }
 
+var cn=Object.defineProperty,un=Object.defineProperties;var fn=Object.getOwnPropertyDescriptors;var $=Object.getOwnPropertySymbols;var dn=Object.prototype.hasOwnProperty,gn=Object.prototype.propertyIsEnumerable;var O=(n,r,e)=>r in n?cn(n,r,{enumerable:true,configurable:true,writable:true,value:e}):n[r]=e,I=(n,r)=>{for(var e in r||(r={}))dn.call(r,e)&&O(n,e,r[e]);if($)for(var e of $(r))gn.call(r,e)&&O(n,e,r[e]);return n},k=(n,r)=>un(n,fn(r));var c=(n,r)=>{let e=false,i=false;for(let s=0;s<r;s+=1){if(n[s]==="\\"&&s+1<n.length&&n[s+1]==="`"){s+=1;continue}if(n.substring(s,s+3)==="```"){i=!i,s+=2;continue}!i&&n[s]==="`"&&(e=!e);}return e||i},hn=(n,r)=>{let e=n.substring(r,r+3)==="```",i=r>0&&n.substring(r-1,r+2)==="```",s=r>1&&n.substring(r-2,r+1)==="```";return e||i||s},L=n=>{let r=0;for(let e=0;e<n.length;e+=1){if(n[e]==="\\"&&e+1<n.length&&n[e+1]==="`"){e+=1;continue}n[e]==="`"&&!hn(n,e)&&(r+=1);}return r},f=(n,r)=>{let e=false,i=false,s=-1;for(let o=0;o<n.length;o+=1){if(n[o]==="\\"&&o+1<n.length&&n[o+1]==="`"){o+=1;continue}if(n.substring(o,o+3)==="```"){i=!i,o+=2;continue}if(!i&&n[o]==="`")if(e){if(s<r&&r<o)return  true;e=false,s=-1;}else e=true,s=o;}return  false};var mn=/^(\s*(?:[-*+]|\d+[.)]) +)>(=?\s*[$]?\d)/gm,E=n=>!n||typeof n!="string"||!n.includes(">")?n:n.replace(mn,(r,e,i,s)=>c(n,s)?r:`${e}\\>${i}`);var M=/(\*\*)([^*]*\*?)$/,N=/(__)([^_]*?)$/,y=/(\*\*\*)([^*]*?)$/,R=/(\*)([^*]*?)$/,U=/(_)([^_]*?)$/,W=/(`)([^`]*?)$/,K=/(~~)([^~]*?)$/,d=/^[\s_~*`]*$/,b=/^[\s]*[-*+][\s]+$/,H=/[\p{L}\p{N}_]/u,D=/^```[^`\n]*```?$/,w=/^\*{4,}$/;var G=/(__)([^_]+)_$/,F=/(~~)([^~]+)~$/;var T=/~~/g;var g=n=>{if(!n)return  false;let r=n.charCodeAt(0);return r>=48&&r<=57||r>=65&&r<=90||r>=97&&r<=122||r===95?true:H.test(n)},pn=(n,r)=>{let e=false;for(let i=0;i<r;i+=1)n[i]==="`"&&n[i+1]==="`"&&n[i+2]==="`"&&(e=!e,i+=2);return e},X=(n,r)=>{let e=1;for(let i=r-1;i>=0;i-=1)if(n[i]==="]")e+=1;else if(n[i]==="["&&(e-=1,e===0))return i;return  -1},C=(n,r)=>{let e=1;for(let i=r+1;i<n.length;i+=1)if(n[i]==="[")e+=1;else if(n[i]==="]"&&(e-=1,e===0))return i;return  -1},h=(n,r)=>{let e=false,i=false;for(let s=0;s<n.length&&s<r;s+=1){if(n[s]==="\\"&&n[s+1]==="$"){s+=1;continue}n[s]==="$"&&(n[s+1]==="$"?(i=!i,s+=1,e=false):i||(e=!e));}return e||i},In=(n,r)=>{for(let e=r;e<n.length;e+=1){if(n[e]===")")return  true;if(n[e]===`
+`)return  false}return  false},m=(n,r)=>{for(let e=r-1;e>=0;e-=1){if(n[e]===")")return  false;if(n[e]==="(")return e>0&&n[e-1]==="]"?In(n,r):false;if(n[e]===`
+`)return  false}return  false},z=(n,r)=>{for(let e=r-1;e>=0;e-=1){if(n[e]===">")return  false;if(n[e]==="<"){let i=e+1<n.length?n[e+1]:"";return i>="a"&&i<="z"||i>="A"&&i<="Z"||i==="/"}if(n[e]===`
+`)return  false}return  false},p=(n,r,e)=>{let i=0;for(let l=r-1;l>=0;l-=1)if(n[l]===`
+`){i=l+1;break}let s=n.length;for(let l=r;l<n.length;l+=1)if(n[l]===`
+`){s=l;break}let o=n.substring(i,s),t=0,a=false;for(let l of o)if(l===e)t+=1;else if(l!==" "&&l!=="	"){a=true;break}return t>=3&&!a};var kn=(n,r,e,i)=>e==="\\"||n.includes("$")&&h(n,r)?true:e!=="*"&&i==="*"?(r<n.length-2?n[r+2]:"")!=="*":!!(e==="*"||e&&i&&g(e)&&g(i)||(!e||e===" "||e==="	"||e===`
+`)&&(!i||i===" "||i==="	"||i===`
+`)),Y=n=>{let r=0,e=false,i=n.length;for(let s=0;s<i;s+=1){if(n[s]==="`"&&s+2<i&&n[s+1]==="`"&&n[s+2]==="`"){e=!e,s+=2;continue}if(e||n[s]!=="*")continue;let o=s>0?n[s-1]:"",t=s<i-1?n[s+1]:"";kn(n,s,o,t)||(r+=1);}return r},bn=(n,r,e,i)=>!!(e==="\\"||n.includes("$")&&h(n,r)||m(n,r)||z(n,r)||e==="_"||i==="_"||e&&i&&g(e)&&g(i)),Tn=n=>{let r=0,e=false,i=n.length;for(let s=0;s<i;s+=1){if(n[s]==="`"&&s+2<i&&n[s+1]==="`"&&n[s+2]==="`"){e=!e,s+=2;continue}if(e||n[s]!=="_")continue;let o=s>0?n[s-1]:"",t=s<i-1?n[s+1]:"";bn(n,s,o,t)||(r+=1);}return r},Cn=n=>{let r=0,e=0,i=false;for(let s=0;s<n.length;s+=1){if(n[s]==="`"&&s+2<n.length&&n[s+1]==="`"&&n[s+2]==="`"){e>=3&&(r+=Math.floor(e/3)),e=0,i=!i,s+=2;continue}i||(n[s]==="*"?e+=1:(e>=3&&(r+=Math.floor(e/3)),e=0));}return e>=3&&(r+=Math.floor(e/3)),r},A=n=>{let r=0,e=false;for(let i=0;i<n.length;i+=1){if(n[i]==="`"&&i+2<n.length&&n[i+1]==="`"&&n[i+2]==="`"){e=!e,i+=2;continue}e||n[i]==="*"&&i+1<n.length&&n[i+1]==="*"&&(r+=1,i+=1);}return r},v=n=>{let r=0,e=false;for(let i=0;i<n.length;i+=1){if(n[i]==="`"&&i+2<n.length&&n[i+1]==="`"&&n[i+2]==="`"){e=!e,i+=2;continue}e||n[i]==="_"&&i+1<n.length&&n[i+1]==="_"&&(r+=1,i+=1);}return r},An=(n,r,e)=>{if(!r||d.test(r))return  true;let s=n.substring(0,e).lastIndexOf(`
+`),o=s===-1?0:s+1,t=n.substring(o,e);return b.test(t)&&r.includes(`
+`)?true:p(n,e,"*")},j=n=>{let r=n.match(M);if(!r)return n;let e=r[2],i=n.lastIndexOf(r[1]);return c(n,i)||f(n,i)||An(n,e,i)?n:A(n)%2===1?e.endsWith("*")?`${n}*`:`${n}**`:n},Bn=(n,r,e)=>{if(!r||d.test(r))return  true;let s=n.substring(0,e).lastIndexOf(`
+`),o=s===-1?0:s+1,t=n.substring(o,e);return b.test(t)&&r.includes(`
+`)?true:p(n,e,"_")},Q=n=>{let r=n.match(N);if(!r){let o=n.match(G);if(o){let t=n.lastIndexOf(o[1]);if(!(c(n,t)||f(n,t))&&v(n)%2===1)return `${n}_`}return n}let e=r[2],i=n.lastIndexOf(r[1]);return c(n,i)||f(n,i)||Bn(n,e,i)?n:v(n)%2===1?`${n}__`:n},Sn=n=>{let r=false;for(let e=0;e<n.length;e+=1){if(n[e]==="`"&&e+2<n.length&&n[e+1]==="`"&&n[e+2]==="`"){r=!r,e+=2;continue}if(!r&&n[e]==="*"&&n[e-1]!=="*"&&n[e+1]!=="*"&&n[e-1]!=="\\"&&!h(n,e)){let i=e>0?n[e-1]:"",s=e<n.length-1?n[e+1]:"";if((!i||i===" "||i==="	"||i===`
+`)&&(!s||s===" "||s==="	"||s===`
+`)||i&&s&&g(i)&&g(s))continue;return e}}return  -1},Z=n=>{if(!n.match(R))return n;let e=Sn(n);if(e===-1||c(n,e)||f(n,e))return n;let i=n.substring(e+1);return !i||d.test(i)?n:Y(n)%2===1?`${n}*`:n},q=n=>{let r=false;for(let e=0;e<n.length;e+=1){if(n[e]==="`"&&e+2<n.length&&n[e+1]==="`"&&n[e+2]==="`"){r=!r,e+=2;continue}if(!r&&n[e]==="_"&&n[e-1]!=="_"&&n[e+1]!=="_"&&n[e-1]!=="\\"&&!h(n,e)&&!m(n,e)){let i=e>0?n[e-1]:"",s=e<n.length-1?n[e+1]:"";if(i&&s&&g(i)&&g(s))continue;return e}}return  -1},_n=n=>{let r=n.length;for(;r>0&&n[r-1]===`
+`;)r-=1;if(r<n.length){let e=n.slice(0,r),i=n.slice(r);return `${e}_${i}`}return `${n}_`},Pn=n=>{if(!n.endsWith("**"))return null;let r=n.slice(0,-2);if(A(r)%2!==1)return null;let i=r.indexOf("**"),s=q(r);return i!==-1&&s!==-1&&i<s?`${r}_**`:null},J=n=>{if(!n.match(U))return n;let e=q(n);if(e===-1)return n;let i=n.substring(e+1);if(!i||d.test(i)||c(n,e)||f(n,e))return n;if(Tn(n)%2===1){let o=Pn(n);return o!==null?o:_n(n)}return n},$n=n=>{let r=A(n),e=Y(n);return r%2===0&&e%2===0},On=(n,r,e)=>!r||d.test(r)||c(n,e)||f(n,e)?true:p(n,e,"*"),V=n=>{if(w.test(n))return n;let r=n.match(y);if(!r)return n;let e=r[2],i=n.lastIndexOf(r[1]);return On(n,e,i)?n:Cn(n)%2===1?$n(n)?n:`${n}***`:n};var Ln=/<[a-zA-Z/][^>]*$/,x=n=>{let r=n.match(Ln);return !r||r.index===void 0||c(n,r.index)?n:n.substring(0,r.index).trimEnd()};var En=n=>!n.match(D)||n.includes(`
+`)?null:n.endsWith("``")&&!n.endsWith("```")?`${n}\``:n,Mn=n=>(n.match(/```/g)||[]).length%2===1,nn=n=>{let r=En(n);if(r!==null)return r;let e=n.match(W);if(e&&!Mn(n)){let i=e[2];if(!i||d.test(i))return n;if(L(n)%2===1)return `${n}\``}return n};var en=(n,r)=>r>=2&&n.substring(r-2,r+1)==="```"||r>=1&&n.substring(r-1,r+2)==="```"||r<=n.length-3&&n.substring(r,r+3)==="```",Nn=n=>{let r=0,e=false;for(let i=0;i<n.length-1;i+=1)n[i]==="`"&&!en(n,i)&&(e=!e),!e&&n[i]==="$"&&n[i+1]==="$"&&(r+=1,i+=1);return r},yn=n=>{let r=0,e=false;for(let i=0;i<n.length;i+=1){if(n[i]==="\\"){i+=1;continue}if(n[i]==="`"&&!en(n,i)){e=!e;continue}!e&&n[i]==="$"&&(i+1<n.length&&n[i+1]==="$"?i+=1:r+=1);}return r},Rn=n=>{if(n.endsWith("$")&&!n.endsWith("$$"))return `${n}$`;let r=n.indexOf("$$");return r!==-1&&n.indexOf(`
+`,r)!==-1&&!n.endsWith(`
+`)?`${n}
+$$`:`${n}$$`},rn=n=>Nn(n)%2===0?n:Rn(n),sn=n=>yn(n)%2===1?`${n}$`:n;var Un=(n,r,e)=>{if(n.substring(r+2).includes(")"))return null;let s=X(n,r);if(s===-1||c(n,s))return null;let o=s>0&&n[s-1]==="!",t=o?s-1:s,a=n.substring(0,t);if(o)return a;let l=n.substring(s+1,r);return e==="text-only"?`${a}${l}`:`${a}[${l}](streamdown:incomplete-link)`},on=(n,r)=>{for(let e=0;e<r;e++)if(n[e]==="["&&!c(n,e)){if(e>0&&n[e-1]==="!")continue;let i=C(n,e);if(i===-1)return e;if(i+1<n.length&&n[i+1]==="("){let s=n.indexOf(")",i+2);s!==-1&&(e=s);}}return r},Wn=(n,r,e)=>{let i=r>0&&n[r-1]==="!",s=i?r-1:r;if(!n.substring(r+1).includes("]")){let a=n.substring(0,s);if(i)return a;if(e==="text-only"){let l=on(n,r);return n.substring(0,l)+n.substring(l+1)}return `${n}](streamdown:incomplete-link)`}if(C(n,r)===-1){let a=n.substring(0,s);if(i)return a;if(e==="text-only"){let l=on(n,r);return n.substring(0,l)+n.substring(l+1)}return `${n}](streamdown:incomplete-link)`}return null},B=(n,r="protocol")=>{let e=n.lastIndexOf("](");if(e!==-1&&!c(n,e)){let i=Un(n,e,r);if(i!==null)return i}for(let i=n.length-1;i>=0;i-=1)if(n[i]==="["&&!c(n,i)){let s=Wn(n,i,r);if(s!==null)return s}return n};var Kn=/^-{1,2}$/,Hn=/^[\s]*-{1,2}[\s]+$/,Dn=/^={1,2}$/,wn=/^[\s]*={1,2}[\s]+$/,ln=n=>{if(!n||typeof n!="string")return n;let r=n.lastIndexOf(`
+`);if(r===-1)return n;let e=n.substring(r+1),i=n.substring(0,r),s=e.trim();if(Kn.test(s)&&!e.match(Hn)){let t=i.split(`
+`).at(-1);if(t&&t.trim().length>0)return `${n}\u200B`}if(Dn.test(s)&&!e.match(wn)){let t=i.split(`
+`).at(-1);if(t&&t.trim().length>0)return `${n}\u200B`}return n};var Gn=new RegExp("(?<=[\\p{L}\\p{N}_])~(?!~)(?=[\\p{L}\\p{N}_])","gu"),tn=n=>!n||typeof n!="string"||!n.includes("~")?n:n.replace(Gn,(r,e)=>c(n,e)?r:"\\~");var an=n=>{var e,i;let r=n.match(K);if(r){let s=r[2];if(!s||d.test(s))return n;let o=n.lastIndexOf(r[1]);if(c(n,o)||f(n,o))return n;if(((e=n.match(T))==null?void 0:e.length)%2===1)return `${n}~~`}else {let s=n.match(F);if(s){let o=n.lastIndexOf(s[0].slice(0,2));if(c(n,o)||f(n,o))return n;if(((i=n.match(T))==null?void 0:i.length)%2===1)return `${n}~`}}return n};var S=n=>n!==false,Fn=n=>n===true,u={SINGLE_TILDE:0,COMPARISON_OPERATORS:5,HTML_TAGS:10,SETEXT_HEADINGS:15,LINKS:20,BOLD_ITALIC:30,BOLD:35,ITALIC_DOUBLE_UNDERSCORE:40,ITALIC_SINGLE_ASTERISK:41,ITALIC_SINGLE_UNDERSCORE:42,INLINE_CODE:50,STRIKETHROUGH:60,KATEX:70,INLINE_KATEX:75,DEFAULT:100},Xn=[{handler:{name:"singleTilde",handle:tn,priority:u.SINGLE_TILDE},optionKey:"singleTilde"},{handler:{name:"comparisonOperators",handle:E,priority:u.COMPARISON_OPERATORS},optionKey:"comparisonOperators"},{handler:{name:"htmlTags",handle:x,priority:u.HTML_TAGS},optionKey:"htmlTags"},{handler:{name:"setextHeadings",handle:ln,priority:u.SETEXT_HEADINGS},optionKey:"setextHeadings"},{handler:{name:"links",handle:B,priority:u.LINKS},optionKey:"links",earlyReturn:n=>n.endsWith("](streamdown:incomplete-link)")},{handler:{name:"boldItalic",handle:V,priority:u.BOLD_ITALIC},optionKey:"boldItalic"},{handler:{name:"bold",handle:j,priority:u.BOLD},optionKey:"bold"},{handler:{name:"italicDoubleUnderscore",handle:Q,priority:u.ITALIC_DOUBLE_UNDERSCORE},optionKey:"italic"},{handler:{name:"italicSingleAsterisk",handle:Z,priority:u.ITALIC_SINGLE_ASTERISK},optionKey:"italic"},{handler:{name:"italicSingleUnderscore",handle:J,priority:u.ITALIC_SINGLE_UNDERSCORE},optionKey:"italic"},{handler:{name:"inlineCode",handle:nn,priority:u.INLINE_CODE},optionKey:"inlineCode"},{handler:{name:"strikethrough",handle:an,priority:u.STRIKETHROUGH},optionKey:"strikethrough"},{handler:{name:"katex",handle:rn,priority:u.KATEX},optionKey:"katex"},{handler:{name:"inlineKatex",handle:sn,priority:u.INLINE_KATEX},optionKey:"inlineKatex"}],zn=n=>{var e;let r=(e=n==null?void 0:n.linkMode)!=null?e:"protocol";return Xn.filter(({handler:i,optionKey:s})=>i.name==="links"?S(n==null?void 0:n.links)||S(n==null?void 0:n.images):i.name==="inlineKatex"?Fn(n==null?void 0:n.inlineKatex):S(n==null?void 0:n[s])).map(({handler:i,earlyReturn:s})=>i.name==="links"?{handler:k(I({},i),{handle:o=>B(o,r)}),earlyReturn:r==="protocol"?s:void 0}:{handler:i,earlyReturn:s})},vn=(n,r)=>{var t;if(!n||typeof n!="string")return n;let e=n.endsWith(" ")&&!n.endsWith("  ")?n.slice(0,-1):n,i=zn(r),s=((t=r==null?void 0:r.handlers)!=null?t:[]).map(a=>{var l;return {handler:k(I({},a),{priority:(l=a.priority)!=null?l:u.DEFAULT}),earlyReturn:void 0}}),o=[...i,...s].sort((a,l)=>{var _,P;return ((_=a.handler.priority)!=null?_:0)-((P=l.handler.priority)!=null?P:0)});for(let{handler:a,earlyReturn:l}of o)if(e=a.handle(e),l!=null&&l(e))return e;return e},$e=vn;
+
 const MAX_COMMENT_LENGTH = 65536;
 const TRUNCATION_BUFFER = 4096;
 const SAFE_BODY_LENGTH = MAX_COMMENT_LENGTH - TRUNCATION_BUFFER;
-const SIMPLE_SUFFIX = '\n\n---\n**This message was truncated.**';
-function artifactSuffix(url) {
-    return `\n\n---\n**This message was truncated.** [Download full message](${url})`;
+const DEFAULT_SEPARATOR = '---';
+function terminateMarkdown(text) {
+    let result = $e(text);
+    const end = result.length - 1;
+    if (pn(result, end)) {
+        result += '\n```';
+    }
+    if (h(result, end)) {
+        result += '\n$$';
+    }
+    return result;
 }
-async function truncateMessage(message, mode, headerLength, messageId) {
+function simpleSuffix(separator) {
+    return `\n\n${separator}\n**This message was truncated.**`;
+}
+function artifactSuffix(url, separator) {
+    return `\n\n${separator}\n**This message was truncated.** [Download full message](${url})`;
+}
+async function truncateMessage(message, mode, headerLength, messageId, truncateSeparator) {
     const budget = SAFE_BODY_LENGTH - headerLength;
+    const separator = truncateSeparator || DEFAULT_SEPARATOR;
     if (message.length <= budget) {
         return { message, truncated: false };
     }
     warning(`Message length ${message.length} exceeds safe limit ${budget}, truncating`);
     if (mode === 'simple') {
-        const truncated = message.substring(0, budget - SIMPLE_SUFFIX.length) + SIMPLE_SUFFIX;
+        const suffix = simpleSuffix(separator);
+        const cut = terminateMarkdown(message.substring(0, budget - suffix.length));
+        const truncated = cut + suffix;
         return { message: truncated, truncated: true };
     }
     // artifact mode: upload full message, truncate comment with link
@@ -120402,13 +120444,16 @@ async function truncateMessage(message, mode, headerLength, messageId) {
         }
         const { repo, owner } = context$2.repo;
         const artifactUrl = `https://github.com/${owner}/${repo}/actions/runs/${context$2.runId}/artifacts/${id}`;
-        const suffix = artifactSuffix(artifactUrl);
-        const truncated = message.substring(0, budget - suffix.length) + suffix;
+        const suffix = artifactSuffix(artifactUrl, separator);
+        const cut = terminateMarkdown(message.substring(0, budget - suffix.length));
+        const truncated = cut + suffix;
         return { message: truncated, truncated: true, artifactUrl };
     }
     catch {
         warning('Failed to upload truncated message artifact, falling back to simple truncation');
-        const truncated = message.substring(0, budget - SIMPLE_SUFFIX.length) + SIMPLE_SUFFIX;
+        const suffix = simpleSuffix(separator);
+        const cut = terminateMarkdown(message.substring(0, budget - suffix.length));
+        const truncated = cut + suffix;
         return { message: truncated, truncated: true };
     }
 }
@@ -120543,7 +120588,7 @@ async function manageComment(adapter, options) {
 }
 const run = async () => {
     try {
-        const { allowRepeats, attachName, attachPath, attachText, commentTarget, messagePath, messageInput, messageId, refreshMessagePosition, repoToken, proxyUrl, issue, pullRequestNumber, commitSha, repo, owner, updateOnly, deleteOnStatus, messageCancelled, messageFailure, messageSuccess, messageSkipped, preformatted, status, messageFind, messageReplace, truncate, } = await getInputs();
+        const { allowRepeats, attachName, attachPath, attachText, commentTarget, messagePath, messageInput, messageId, refreshMessagePosition, repoToken, proxyUrl, issue, pullRequestNumber, commitSha, repo, owner, updateOnly, deleteOnStatus, messageCancelled, messageFailure, messageSuccess, messageSkipped, preformatted, status, messageFind, messageReplace, truncate, truncateSeparator, } = await getInputs();
         const octokit = getOctokit(repoToken);
         let message = await getMessage({
             messagePath,
@@ -120571,7 +120616,7 @@ const run = async () => {
         }
         const headerLength = messageId.length + 2; // messageId + '\n\n' from addMessageHeader
         if (message) {
-            const truncateResult = await truncateMessage(message, truncate, headerLength, messageId);
+            const truncateResult = await truncateMessage(message, truncate, headerLength, messageId, truncateSeparator);
             message = truncateResult.message;
             setOutput('truncated', truncateResult.truncated ? 'true' : 'false');
             if (truncateResult.artifactUrl) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -120432,6 +120432,18 @@ function simpleSuffix(separator) {
 function artifactSuffix(url, separator) {
     return `\n\n${separator}\n**This message was truncated.** [Download full message](${url})`;
 }
+// Reserve space for closing markers that terminateMarkdown may add (e.g. \n``` or \n$$)
+const TERMINATION_RESERVE = 16;
+function truncateAndTerminate(message, budget, suffix) {
+    const maxCutLength = budget - suffix.length;
+    const breakAt = findBreakpoint(message, maxCutLength - TERMINATION_RESERVE);
+    let cut = terminateMarkdown(message.substring(0, breakAt));
+    // Safety net: if termination still exceeds budget, hard-truncate
+    if (cut.length > maxCutLength) {
+        cut = cut.substring(0, maxCutLength);
+    }
+    return cut + suffix;
+}
 async function truncateMessage(message, mode, headerLength, messageId, truncateSeparator) {
     const budget = SAFE_BODY_LENGTH - headerLength;
     const separator = truncateSeparator || DEFAULT_SEPARATOR;
@@ -120441,9 +120453,7 @@ async function truncateMessage(message, mode, headerLength, messageId, truncateS
     warning(`Message length ${message.length} exceeds safe limit ${budget}, truncating`);
     if (mode === 'simple') {
         const suffix = simpleSuffix(separator);
-        const breakAt = findBreakpoint(message, budget - suffix.length);
-        const cut = terminateMarkdown(message.substring(0, breakAt));
-        const truncated = cut + suffix;
+        const truncated = truncateAndTerminate(message, budget, suffix);
         return { message: truncated, truncated: true };
     }
     // artifact mode: upload full message, truncate comment with link
@@ -120461,17 +120471,13 @@ async function truncateMessage(message, mode, headerLength, messageId, truncateS
         const { repo, owner } = context$2.repo;
         const artifactUrl = `https://github.com/${owner}/${repo}/actions/runs/${context$2.runId}/artifacts/${id}`;
         const suffix = artifactSuffix(artifactUrl, separator);
-        const breakAt = findBreakpoint(message, budget - suffix.length);
-        const cut = terminateMarkdown(message.substring(0, breakAt));
-        const truncated = cut + suffix;
+        const truncated = truncateAndTerminate(message, budget, suffix);
         return { message: truncated, truncated: true, artifactUrl };
     }
     catch {
         warning('Failed to upload truncated message artifact, falling back to simple truncation');
         const suffix = simpleSuffix(separator);
-        const breakAt = findBreakpoint(message, budget - suffix.length);
-        const cut = terminateMarkdown(message.substring(0, breakAt));
-        const truncated = cut + suffix;
+        const truncated = truncateAndTerminate(message, budget, suffix);
         return { message: truncated, truncated: true };
     }
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -120400,6 +120400,21 @@ const MAX_COMMENT_LENGTH = 65536;
 const TRUNCATION_BUFFER = 4096;
 const SAFE_BODY_LENGTH = MAX_COMMENT_LENGTH - TRUNCATION_BUFFER;
 const DEFAULT_SEPARATOR = '---';
+function findBreakpoint(text, maxLength) {
+    if (maxLength >= text.length)
+        return text.length;
+    // Search backwards within half the truncation buffer for a natural break
+    const searchLimit = Math.floor(TRUNCATION_BUFFER / 2);
+    const earliest = Math.max(0, maxLength - searchLimit);
+    for (let i = maxLength; i > earliest; i--) {
+        const ch = text[i];
+        if (ch === '\n' || ch === ' ' || ch === '\t') {
+            return i + 1;
+        }
+    }
+    // No natural break found, fall back to hard cut
+    return maxLength;
+}
 function terminateMarkdown(text) {
     let result = $e(text);
     const end = result.length - 1;
@@ -120426,7 +120441,8 @@ async function truncateMessage(message, mode, headerLength, messageId, truncateS
     warning(`Message length ${message.length} exceeds safe limit ${budget}, truncating`);
     if (mode === 'simple') {
         const suffix = simpleSuffix(separator);
-        const cut = terminateMarkdown(message.substring(0, budget - suffix.length));
+        const breakAt = findBreakpoint(message, budget - suffix.length);
+        const cut = terminateMarkdown(message.substring(0, breakAt));
         const truncated = cut + suffix;
         return { message: truncated, truncated: true };
     }
@@ -120445,14 +120461,16 @@ async function truncateMessage(message, mode, headerLength, messageId, truncateS
         const { repo, owner } = context$2.repo;
         const artifactUrl = `https://github.com/${owner}/${repo}/actions/runs/${context$2.runId}/artifacts/${id}`;
         const suffix = artifactSuffix(artifactUrl, separator);
-        const cut = terminateMarkdown(message.substring(0, budget - suffix.length));
+        const breakAt = findBreakpoint(message, budget - suffix.length);
+        const cut = terminateMarkdown(message.substring(0, breakAt));
         const truncated = cut + suffix;
         return { message: truncated, truncated: true, artifactUrl };
     }
     catch {
         warning('Failed to upload truncated message artifact, falling back to simple truncation');
         const suffix = simpleSuffix(separator);
-        const cut = terminateMarkdown(message.substring(0, budget - suffix.length));
+        const breakAt = findBreakpoint(message, budget - suffix.length);
+        const cut = terminateMarkdown(message.substring(0, breakAt));
         const truncated = cut + suffix;
         return { message: truncated, truncated: true };
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@actions/core": "^3.0.0",
         "@actions/github": "^9.0.0",
         "@actions/glob": "^0.6.1",
-        "@actions/http-client": "^4.0.0"
+        "@actions/http-client": "^4.0.0",
+        "remend": "^1.3.0"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.6",
@@ -3940,6 +3941,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/remend": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/remend/-/remend-1.3.0.tgz",
+      "integrity": "sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==",
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "@actions/core": "^3.0.0",
     "@actions/github": "^9.0.0",
     "@actions/glob": "^0.6.1",
-    "@actions/http-client": "^4.0.0"
+    "@actions/http-client": "^4.0.0",
+    "remend": "^1.3.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.6",

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -41,6 +41,7 @@ type Inputs = {
   'delete-on-status'?: string
   preformatted?: string
   truncate?: string
+  'truncate-separator'?: string
   find?: string
   replace?: string
   status?: 'success' | 'failure' | 'cancelled' | 'skipped'
@@ -299,6 +300,30 @@ describe('add-pr-comment action', () => {
     expect(messagePayload?.body).toContain('**This message was truncated.**')
     expect(core.setOutput).toHaveBeenCalledWith('truncated', 'true')
     expect(messagePayload?.body.length).toBeLessThanOrEqual(61440)
+  })
+
+  it('truncates with a custom separator', async () => {
+    inputs.message = 'x'.repeat(70000)
+    inputs['allow-repeats'] = 'true'
+    inputs['truncate-separator'] = '```\n\n---'
+
+    await expect(run()).resolves.not.toThrow()
+    expect(messagePayload?.body).toContain('\n\n```\n\n---\n**This message was truncated.**')
+    expect(core.setOutput).toHaveBeenCalledWith('truncated', 'true')
+    expect(messagePayload?.body.length).toBeLessThanOrEqual(61440)
+  })
+
+  it('terminates incomplete markdown when truncating', async () => {
+    // Message with an unclosed code fence
+    inputs.message = `\`\`\`\n${'x'.repeat(70000)}\n\`\`\``
+    inputs['allow-repeats'] = 'true'
+
+    await expect(run()).resolves.not.toThrow()
+    expect(messagePayload?.body).toContain('**This message was truncated.**')
+    const beforeSuffix = messagePayload?.body.split('\n\n---\n**This message was truncated.**')[0]
+    // remend + terminateMarkdown should close the open code fence
+    const fences = beforeSuffix?.match(/```/g) || []
+    expect(fences.length % 2).toBe(0)
   })
 
   it('does not truncate a message under the safe limit', async () => {

--- a/src/action.ts
+++ b/src/action.ts
@@ -146,6 +146,7 @@ export const run = async (): Promise<void> => {
       messageFind,
       messageReplace,
       truncate,
+      truncateSeparator,
     } = await getInputs()
 
     const octokit = github.getOctokit(repoToken)
@@ -179,7 +180,13 @@ export const run = async (): Promise<void> => {
     const headerLength = messageId.length + 2 // messageId + '\n\n' from addMessageHeader
 
     if (message) {
-      const truncateResult = await truncateMessage(message, truncate, headerLength, messageId)
+      const truncateResult = await truncateMessage(
+        message,
+        truncate,
+        headerLength,
+        messageId,
+        truncateSeparator,
+      )
       message = truncateResult.message
       core.setOutput('truncated', truncateResult.truncated ? 'true' : 'false')
       if (truncateResult.artifactUrl) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,7 @@ export async function getInputs(): Promise<Inputs> {
     throw new Error(`Invalid truncate mode: "${truncateInput}". Must be "artifact" or "simple".`)
   }
   const truncate = truncateInput as 'artifact' | 'simple'
+  const truncateSeparator = core.getInput('truncate-separator', { required: false })
   const deleteOnStatus = core.getInput('delete-on-status', { required: false })
 
   const commentTarget = core.getInput('comment-target', { required: false }) || 'pr'
@@ -64,6 +65,7 @@ export async function getInputs(): Promise<Inputs> {
     messageReplace,
     preformatted,
     truncate,
+    truncateSeparator: truncateSeparator || undefined,
     proxyUrl,
     pullRequestNumber: payload.pull_request?.number,
     refreshMessagePosition,

--- a/src/message.test.ts
+++ b/src/message.test.ts
@@ -42,6 +42,46 @@ describe('truncateMessage', () => {
     expect(fences.length % 2).toBe(0)
   })
 
+  it('breaks at a natural boundary instead of mid-word', async () => {
+    // Build a message where the cut point lands mid-word
+    // We use words separated by spaces so there's a clear breakpoint to find
+    const word = 'abcdefghij '
+    const longMessage = word.repeat(Math.ceil(70000 / word.length))
+
+    const result = await truncateMessage(longMessage, 'simple', 50)
+
+    expect(result.truncated).toBe(true)
+    const beforeSuffix = result.message.split('\n\n---\n**This message was truncated.**')[0]
+    // Should end at a complete word (remend trims trailing whitespace)
+    // The word is 'abcdefghij' — if we cut mid-word we'd see a partial like 'abcde'
+    expect(beforeSuffix).toMatch(/abcdefghij$/)
+  })
+
+  it('breaks at a newline when available', async () => {
+    // Build a message with lines separated by newlines
+    const line = 'x'.repeat(80) + '\n'
+    const longMessage = line.repeat(Math.ceil(70000 / line.length))
+
+    const result = await truncateMessage(longMessage, 'simple', 50)
+
+    expect(result.truncated).toBe(true)
+    const beforeSuffix = result.message.split('\n\n---\n**This message was truncated.**')[0]
+    // Should end at a line boundary
+    expect(beforeSuffix).toMatch(/\n$/)
+  })
+
+  it('falls back to hard cut when no breakpoint found within search range', async () => {
+    // A message with no spaces or newlines at all
+    const longMessage = 'x'.repeat(70000)
+
+    const result = await truncateMessage(longMessage, 'simple', 50)
+
+    expect(result.truncated).toBe(true)
+    // Should still truncate successfully even without a natural break
+    expect(result.message).toContain('**This message was truncated.**')
+    expect(result.message.length).toBeLessThanOrEqual(65536)
+  })
+
   it('terminates incomplete bold markdown after truncation', async () => {
     // Message with unclosed bold that gets cut
     const longMessage = `**bold text that is very long ${'x'.repeat(70000)}`

--- a/src/message.test.ts
+++ b/src/message.test.ts
@@ -59,7 +59,7 @@ describe('truncateMessage', () => {
 
   it('breaks at a newline when available', async () => {
     // Build a message with lines separated by newlines
-    const line = 'x'.repeat(80) + '\n'
+    const line = `${'x'.repeat(80)}\n`
     const longMessage = line.repeat(Math.ceil(70000 / line.length))
 
     const result = await truncateMessage(longMessage, 'simple', 50)

--- a/src/message.test.ts
+++ b/src/message.test.ts
@@ -82,6 +82,17 @@ describe('truncateMessage', () => {
     expect(result.message.length).toBeLessThanOrEqual(65536)
   })
 
+  it('enforces budget even when markdown termination adds characters', async () => {
+    // Code fence at the start means terminateMarkdown will add \n``` (4 chars)
+    const longMessage = `\`\`\`\n${'x'.repeat(70000)}\n\`\`\``
+
+    const result = await truncateMessage(longMessage, 'simple', 50)
+
+    expect(result.truncated).toBe(true)
+    // SAFE_BODY_LENGTH (61440) - headerLength (50) = 61390 budget
+    expect(result.message.length).toBeLessThanOrEqual(61390)
+  })
+
   it('terminates incomplete bold markdown after truncation', async () => {
     // Message with unclosed bold that gets cut
     const longMessage = `**bold text that is very long ${'x'.repeat(70000)}`

--- a/src/message.test.ts
+++ b/src/message.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { truncateMessage } from './message.js'
+
+describe('truncateMessage', () => {
+  it('does not truncate messages under the budget', async () => {
+    const result = await truncateMessage('short message', 'simple', 50)
+    expect(result.truncated).toBe(false)
+    expect(result.message).toBe('short message')
+  })
+
+  it('uses custom truncate-separator in simple mode', async () => {
+    const longMessage = 'x'.repeat(70000)
+    const separator = '```\n\n---'
+
+    const result = await truncateMessage(longMessage, 'simple', 50, undefined, separator)
+
+    expect(result.truncated).toBe(true)
+    // Should use the custom separator, not the default
+    expect(result.message).toContain('\n\n```\n\n---\n**This message was truncated.**')
+  })
+
+  it('uses default separator when none provided', async () => {
+    const longMessage = 'x'.repeat(70000)
+
+    const result = await truncateMessage(longMessage, 'simple', 50)
+
+    expect(result.truncated).toBe(true)
+    expect(result.message).toContain('\n\n---\n**This message was truncated.**')
+  })
+
+  it('terminates incomplete markdown after truncation', async () => {
+    // Message with an open code fence that will be cut mid-block
+    const longMessage = `\`\`\`\n${'x'.repeat(70000)}\n\`\`\``
+
+    const result = await truncateMessage(longMessage, 'simple', 50)
+
+    expect(result.truncated).toBe(true)
+    // remend should close the open code fence before the suffix
+    const beforeSuffix = result.message.split('\n\n---\n**This message was truncated.**')[0]
+    // Count code fences - should be even (each opened fence is closed)
+    const fences = beforeSuffix.match(/```/g) || []
+    expect(fences.length % 2).toBe(0)
+  })
+
+  it('terminates incomplete bold markdown after truncation', async () => {
+    // Message with unclosed bold that gets cut
+    const longMessage = `**bold text that is very long ${'x'.repeat(70000)}`
+
+    const result = await truncateMessage(longMessage, 'simple', 50)
+
+    expect(result.truncated).toBe(true)
+    const beforeSuffix = result.message.split('\n\n---\n**This message was truncated.**')[0]
+    // remend should close the bold
+    const boldMarkers = beforeSuffix.match(/\*\*/g) || []
+    expect(boldMarkers.length % 2).toBe(0)
+  })
+})

--- a/src/message.ts
+++ b/src/message.ts
@@ -49,6 +49,20 @@ function artifactSuffix(url: string, separator: string) {
   return `\n\n${separator}\n**This message was truncated.** [Download full message](${url})`
 }
 
+// Reserve space for closing markers that terminateMarkdown may add (e.g. \n``` or \n$$)
+const TERMINATION_RESERVE = 16
+
+function truncateAndTerminate(message: string, budget: number, suffix: string): string {
+  const maxCutLength = budget - suffix.length
+  const breakAt = findBreakpoint(message, maxCutLength - TERMINATION_RESERVE)
+  let cut = terminateMarkdown(message.substring(0, breakAt))
+  // Safety net: if termination still exceeds budget, hard-truncate
+  if (cut.length > maxCutLength) {
+    cut = cut.substring(0, maxCutLength)
+  }
+  return cut + suffix
+}
+
 export interface TruncateResult {
   message: string
   truncated: boolean
@@ -73,9 +87,7 @@ export async function truncateMessage(
 
   if (mode === 'simple') {
     const suffix = simpleSuffix(separator)
-    const breakAt = findBreakpoint(message, budget - suffix.length)
-    const cut = terminateMarkdown(message.substring(0, breakAt))
-    const truncated = cut + suffix
+    const truncated = truncateAndTerminate(message, budget, suffix)
     return { message: truncated, truncated: true }
   }
 
@@ -98,17 +110,13 @@ export async function truncateMessage(
     const artifactUrl = `https://github.com/${owner}/${repo}/actions/runs/${github.context.runId}/artifacts/${id}`
 
     const suffix = artifactSuffix(artifactUrl, separator)
-    const breakAt = findBreakpoint(message, budget - suffix.length)
-    const cut = terminateMarkdown(message.substring(0, breakAt))
-    const truncated = cut + suffix
+    const truncated = truncateAndTerminate(message, budget, suffix)
 
     return { message: truncated, truncated: true, artifactUrl }
   } catch {
     core.warning('Failed to upload truncated message artifact, falling back to simple truncation')
     const suffix = simpleSuffix(separator)
-    const breakAt = findBreakpoint(message, budget - suffix.length)
-    const cut = terminateMarkdown(message.substring(0, breakAt))
-    const truncated = cut + suffix
+    const truncated = truncateAndTerminate(message, budget, suffix)
     return { message: truncated, truncated: true }
   }
 }

--- a/src/message.ts
+++ b/src/message.ts
@@ -14,6 +14,21 @@ const SAFE_BODY_LENGTH = MAX_COMMENT_LENGTH - TRUNCATION_BUFFER
 
 const DEFAULT_SEPARATOR = '---'
 
+function findBreakpoint(text: string, maxLength: number): number {
+  if (maxLength >= text.length) return text.length
+  // Search backwards within half the truncation buffer for a natural break
+  const searchLimit = Math.floor(TRUNCATION_BUFFER / 2)
+  const earliest = Math.max(0, maxLength - searchLimit)
+  for (let i = maxLength; i > earliest; i--) {
+    const ch = text[i]
+    if (ch === '\n' || ch === ' ' || ch === '\t') {
+      return i + 1
+    }
+  }
+  // No natural break found, fall back to hard cut
+  return maxLength
+}
+
 function terminateMarkdown(text: string): string {
   let result = remend(text)
   const end = result.length - 1
@@ -58,7 +73,8 @@ export async function truncateMessage(
 
   if (mode === 'simple') {
     const suffix = simpleSuffix(separator)
-    const cut = terminateMarkdown(message.substring(0, budget - suffix.length))
+    const breakAt = findBreakpoint(message, budget - suffix.length)
+    const cut = terminateMarkdown(message.substring(0, breakAt))
     const truncated = cut + suffix
     return { message: truncated, truncated: true }
   }
@@ -82,14 +98,16 @@ export async function truncateMessage(
     const artifactUrl = `https://github.com/${owner}/${repo}/actions/runs/${github.context.runId}/artifacts/${id}`
 
     const suffix = artifactSuffix(artifactUrl, separator)
-    const cut = terminateMarkdown(message.substring(0, budget - suffix.length))
+    const breakAt = findBreakpoint(message, budget - suffix.length)
+    const cut = terminateMarkdown(message.substring(0, breakAt))
     const truncated = cut + suffix
 
     return { message: truncated, truncated: true, artifactUrl }
   } catch {
     core.warning('Failed to upload truncated message artifact, falling back to simple truncation')
     const suffix = simpleSuffix(separator)
-    const cut = terminateMarkdown(message.substring(0, budget - suffix.length))
+    const breakAt = findBreakpoint(message, budget - suffix.length)
+    const cut = terminateMarkdown(message.substring(0, breakAt))
     const truncated = cut + suffix
     return { message: truncated, truncated: true }
   }

--- a/src/message.ts
+++ b/src/message.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { DefaultArtifactClient } from '@actions/artifact'
 import * as core from '@actions/core'
 import * as github from '@actions/github'
+import remend, { isWithinCodeBlock, isWithinMathBlock } from 'remend'
 import { findFiles } from './files.js'
 import type { Inputs } from './types.js'
 
@@ -11,10 +12,26 @@ const MAX_COMMENT_LENGTH = 65536
 const TRUNCATION_BUFFER = 4096
 const SAFE_BODY_LENGTH = MAX_COMMENT_LENGTH - TRUNCATION_BUFFER
 
-const SIMPLE_SUFFIX = '\n\n---\n**This message was truncated.**'
+const DEFAULT_SEPARATOR = '---'
 
-function artifactSuffix(url: string) {
-  return `\n\n---\n**This message was truncated.** [Download full message](${url})`
+function terminateMarkdown(text: string): string {
+  let result = remend(text)
+  const end = result.length - 1
+  if (isWithinCodeBlock(result, end)) {
+    result += '\n```'
+  }
+  if (isWithinMathBlock(result, end)) {
+    result += '\n$$'
+  }
+  return result
+}
+
+function simpleSuffix(separator: string) {
+  return `\n\n${separator}\n**This message was truncated.**`
+}
+
+function artifactSuffix(url: string, separator: string) {
+  return `\n\n${separator}\n**This message was truncated.** [Download full message](${url})`
 }
 
 export interface TruncateResult {
@@ -28,8 +45,10 @@ export async function truncateMessage(
   mode: 'artifact' | 'simple',
   headerLength: number,
   messageId?: string,
+  truncateSeparator?: string,
 ): Promise<TruncateResult> {
   const budget = SAFE_BODY_LENGTH - headerLength
+  const separator = truncateSeparator || DEFAULT_SEPARATOR
 
   if (message.length <= budget) {
     return { message, truncated: false }
@@ -38,7 +57,9 @@ export async function truncateMessage(
   core.warning(`Message length ${message.length} exceeds safe limit ${budget}, truncating`)
 
   if (mode === 'simple') {
-    const truncated = message.substring(0, budget - SIMPLE_SUFFIX.length) + SIMPLE_SUFFIX
+    const suffix = simpleSuffix(separator)
+    const cut = terminateMarkdown(message.substring(0, budget - suffix.length))
+    const truncated = cut + suffix
     return { message: truncated, truncated: true }
   }
 
@@ -60,13 +81,16 @@ export async function truncateMessage(
     const { repo, owner } = github.context.repo
     const artifactUrl = `https://github.com/${owner}/${repo}/actions/runs/${github.context.runId}/artifacts/${id}`
 
-    const suffix = artifactSuffix(artifactUrl)
-    const truncated = message.substring(0, budget - suffix.length) + suffix
+    const suffix = artifactSuffix(artifactUrl, separator)
+    const cut = terminateMarkdown(message.substring(0, budget - suffix.length))
+    const truncated = cut + suffix
 
     return { message: truncated, truncated: true, artifactUrl }
   } catch {
     core.warning('Failed to upload truncated message artifact, falling back to simple truncation')
-    const truncated = message.substring(0, budget - SIMPLE_SUFFIX.length) + SIMPLE_SUFFIX
+    const suffix = simpleSuffix(separator)
+    const cut = terminateMarkdown(message.substring(0, budget - suffix.length))
+    const truncated = cut + suffix
     return { message: truncated, truncated: true }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface Inputs {
   messageSkipped?: string
   preformatted: boolean
   truncate: 'artifact' | 'simple'
+  truncateSeparator?: string
   proxyUrl?: string
   pullRequestNumber?: number
   refreshMessagePosition: boolean


### PR DESCRIPTION
## Summary

Closes #183.

- **Markdown termination**: Uses the [remend](https://www.npmjs.com/package/remend) library to properly close incomplete inline markdown (bold, italic, inline code, strikethrough, links) when truncating. Also detects and closes unclosed fenced code blocks and math blocks.
- **Natural breakpoints**: Instead of cutting mid-word, searches backwards from the cut point (up to half the truncation buffer) for a space, newline, or tab. Falls back to a hard cut if no natural breakpoint is found.
- **Configurable separator**: Adds a new `truncate-separator` input (defaults to `---`) so users can customize the separator before the truncation notice. This is especially useful when messages are wrapped in code fences or collapsible sections, where the default `---` would render inside the block.

### Example usage

```yaml
- uses: mshick/add-pr-comment@v3
  with:
    message: |
      ```
      ${{ steps.plan.outputs.stdout }}
      ```
    truncate-separator: |
      ```

      ---
```

## Test plan

- [x] Unit tests for `truncateMessage` with custom separator, default separator, code fence termination, and bold termination
- [x] Unit tests for natural breakpoint: breaks at word boundary, breaks at newline, falls back to hard cut when no whitespace
- [x] Integration tests for custom separator and markdown termination through the full action flow
- [x] All 63 tests pass
- [x] TypeScript type check passes
- [x] Build succeeds