### PR TITLE
fix: skip comment creation when `deleteOnStatus` matches `status`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -120574,10 +120574,16 @@ async function manageComment(adapter, options) {
         setOutput('comment-created', 'false');
         return;
     }
-    if (deleteOnStatus && existingComment && deleteOnStatus === status) {
-        info('deleting existing comment because delete-comment-on-status matched');
-        await adapter.delete(existingComment.id);
-        setOutput('comment-deleted', 'true');
+    if (deleteOnStatus && deleteOnStatus === status) {
+        if (existingComment) {
+            info('deleting existing comment because delete-comment-on-status matched');
+            await adapter.delete(existingComment.id);
+            setOutput('comment-deleted', 'true');
+        }
+        else {
+            info('skipping creating comment because delete-comment-on-status matched');
+            setOutput('comment-created', 'false');
+        }
         return;
     }
     if (messageFind?.length && (messageReplace?.length || message) && existingComment?.body) {
@@ -120599,11 +120605,8 @@ async function manageComment(adapter, options) {
         setOutput('comment-updated', 'true');
     }
     else {
-        if (deleteOnStatus && deleteOnStatus === status) ;
-        else {
-            comment = await adapter.create(body);
-            setOutput('comment-created', 'true');
-        }
+        comment = await adapter.create(body);
+        setOutput('comment-created', 'true');
     }
     if (comment) {
         setOutput('comment-id', comment.id);

--- a/dist/index.js
+++ b/dist/index.js
@@ -120599,8 +120599,11 @@ async function manageComment(adapter, options) {
         setOutput('comment-updated', 'true');
     }
     else {
-        comment = await adapter.create(body);
-        setOutput('comment-created', 'true');
+        if (deleteOnStatus && deleteOnStatus === status) ;
+        else {
+            comment = await adapter.create(body);
+            setOutput('comment-created', 'true');
+        }
     }
     if (comment) {
         setOutput('comment-id', comment.id);

--- a/src/action.ts
+++ b/src/action.ts
@@ -72,10 +72,15 @@ async function manageComment(
     return
   }
 
-  if (deleteOnStatus && existingComment && deleteOnStatus === status) {
-    core.info('deleting existing comment because delete-comment-on-status matched')
-    await adapter.delete(existingComment.id)
-    core.setOutput('comment-deleted', 'true')
+  if (deleteOnStatus && deleteOnStatus === status) {
+    if (existingComment) {
+      core.info('deleting existing comment because delete-comment-on-status matched')
+      await adapter.delete(existingComment.id)
+      core.setOutput('comment-deleted', 'true')
+    } else {
+      core.info('skipping creating comment because delete-comment-on-status matched')
+      core.setOutput('comment-created', 'false')
+    }
     return
   }
 
@@ -104,12 +109,8 @@ async function manageComment(
     }
     core.setOutput('comment-updated', 'true')
   } else {
-    if (deleteOnStatus && deleteOnStatus === status) {
-      // skip creating comment
-    } else {
-      comment = await adapter.create(body)
-      core.setOutput('comment-created', 'true')
-    }
+    comment = await adapter.create(body)
+    core.setOutput('comment-created', 'true')
   }
 
   if (comment) {

--- a/src/action.ts
+++ b/src/action.ts
@@ -104,9 +104,8 @@ async function manageComment(
     }
     core.setOutput('comment-updated', 'true')
   } else {
-    // Skip creating comment on deleteOnStatus hit
     if (deleteOnStatus && deleteOnStatus === status) {
-      core.setOutput('comment-created', 'false')
+    // skip creating comment
     } else {
       comment = await adapter.create(body)
       core.setOutput('comment-created', 'true')

--- a/src/action.ts
+++ b/src/action.ts
@@ -104,8 +104,13 @@ async function manageComment(
     }
     core.setOutput('comment-updated', 'true')
   } else {
-    comment = await adapter.create(body)
-    core.setOutput('comment-created', 'true')
+    // Skip creating comment on deleteOnStatus hit
+    if (deleteOnStatus && deleteOnStatus === status) {
+      core.setOutput('comment-created', 'false')
+    } else {
+      comment = await adapter.create(body)
+      core.setOutput('comment-created', 'true')
+    }
   }
 
   if (comment) {

--- a/src/action.ts
+++ b/src/action.ts
@@ -105,7 +105,7 @@ async function manageComment(
     core.setOutput('comment-updated', 'true')
   } else {
     if (deleteOnStatus && deleteOnStatus === status) {
-    // skip creating comment
+      // skip creating comment
     } else {
       comment = await adapter.create(body)
       core.setOutput('comment-created', 'true')


### PR DESCRIPTION
This is a slight behaviour change aiming to provide more consistency: prevents creating a new comment should `deleteOnStatus` match `status`

Resolves #189 